### PR TITLE
ci: Pin versions of GitHub Actions to full commit hash

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,5 +7,5 @@ jobs:
     runs-on: ubuntu-24.04
     if: false
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4.0.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0


### PR DESCRIPTION
## What?

This PR pins versions of GitHub Actions to full commit hash by pinact.
In general, this PR doesn't change the behavior of the workflows, so you can merge this safely.

## Why?

The last weekend, the popular GitHub Action tj-actions/changed-files action was compromised.

- https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/
- https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised

All tags were tampered and they pointed to a revision with malicious code.

The issue was solved, but similar issues could happen again.
To avoid this kind of issues, we should pin versions of GitHub Actions.
This is a common practice of GitHub Actions.

https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

> Pin actions to a full length commit SHA
> Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release.
> Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload.
> When selecting a SHA, you should verify it is from the action's repository and not a repository fork.

## How was this pull request created?

This pull request was created by [pinact](https://github.com/suzuki-shunsuke/pinact) and [multi-gitter](https://github.com/lindell/multi-gitter).

## Due Date

Please merge this pull request by 2025-03-31.
If it's difficult, please ask at the Slack channel #sre.

## Contact

If you have any question, please ask at the Slack channel #sre.
